### PR TITLE
Don't merge if any of the values are 'inherit'

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -70,6 +70,10 @@ let tests = [{
     fixture: 'h1{border-color:red;border-width:1px 5px;border-style:dashed}',
     expected: 'h1{border-color:red;border-width:1px 5px;border-style:dashed}',
 }, {
+    message: 'should not merge border with one or more inherit values',
+    fixture: 'h1{border-color:inherit;border-width:1px;border-style:dashed}',
+    expected: 'h1{border-color:inherit;border-width:1px;border-style:dashed}',
+}, {
     message: 'should convert 4 values to 1',
     fixture: 'h1{margin:10px 10px 10px 10px}',
     expected: 'h1{margin:10px}'

--- a/src/lib/canMerge.js
+++ b/src/lib/canMerge.js
@@ -2,5 +2,6 @@
 
 let important = node => node.important;
 let unimportant = node => !node.important;
+let inherit = node => node.value === "inherit";
 
-export default (...props) => props.every(important) || props.every(unimportant);
+export default (...props) => (props.every(important) || props.every(unimportant)) && !props.some(inherit);


### PR DESCRIPTION
Fixes #18.

This could certainly be made more optimal. For instance, if all the values are `inherit` then merging could still take place.