### PR TITLE
Don't merge borders if any of the values is 'initial'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.2
+
+* Fixes an issue where properties with the `initial` keyword were being merged.
+
 # 2.0.1
 
 * Fixed a crash when the module was trying to retrieve declarations

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -110,6 +110,10 @@ let tests = [{
     fixture: 'h1{border-width:3px;border-style:solid;border-color:inherit}',
     expected: 'h1{border-width:3px;border-style:solid;border-color:inherit}',
 }, {
+    message: 'should not merge rules with the initial keyword',
+    fixture: 'h1{border-width:3px;border-style:solid;border-color:initial}',
+    expected: 'h1{border-width:3px;border-style:solid;border-color:initial}',
+}, {
     message: 'should not crash on comments',
     fixture: 'h1{\n  border-width:3px;/* 1 */\n  border-style:solid;/* 2 */\n  border-color:red;/* 3 */}',
     expected: 'h1{/* 1 *//* 2 */\n  border:3px solid red;/* 3 */}'

--- a/src/lib/canMerge.js
+++ b/src/lib/canMerge.js
@@ -3,9 +3,10 @@
 let important = node => node.important;
 let unimportant = node => !node.important;
 let hasInherit = node => ~node.value.indexOf('inherit');
+let hasInitial = node => ~node.value.indexOf('initial');
 
 export default (...props) => {
-    if (props.some(hasInherit)) {
+    if (props.some(hasInherit) || props.some(hasInitial)) {
         return false;
     }
     return props.every(important) || props.every(unimportant);


### PR DESCRIPTION
E.g. `border: initial initial initial;` would not be valid CSS.